### PR TITLE
Update meta.yaml

### DIFF
--- a/recipes/artic/meta.yaml
+++ b/recipes/artic/meta.yaml
@@ -40,8 +40,8 @@ requirements:
     - clint
     - htslib =1.10.2
     - longshot >=0.4.1
-    - medaka >=1.0.3
-    - minimap2 =2.17
+    - medaka >=1.5.0
+    - minimap2 =2.24
     - multiqc
     - muscle >=3.8
     - nanopolish >=0.13.2


### PR DESCRIPTION
Updating medaka to 1.5.0 in artic to allow usage of latest nanopore guppy basecalling models


